### PR TITLE
git workflow: use checkout v3

### DIFF
--- a/.github/workflows/checkstyle.yml
+++ b/.github/workflows/checkstyle.yml
@@ -11,7 +11,7 @@ jobs:
       contents: read
       pull-requests: write 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dbelyaev/action-checkstyle@v0.5.1
         with:
           github_token: ${{ secrets.github_token }}


### PR DESCRIPTION
Fix "Node.js 12 actions are deprecated"